### PR TITLE
Repair and Offline Mode: mouse box-dragging function application in SP

### DIFF
--- a/OpenRA.Mods.Common/Graphics/GlobalButtonOrderSelectionBoxAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/GlobalButtonOrderSelectionBoxAnnotationRenderable.cs
@@ -1,0 +1,72 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.Graphics
+{
+	public struct GlobalButtonOrderSelectionBoxAnnotationRenderable : IRenderable, IFinalizedRenderable
+	{
+		readonly WPos pos;
+		readonly Rectangle decorationBounds;
+		readonly Color color;
+
+		public GlobalButtonOrderSelectionBoxAnnotationRenderable(Actor actor, Rectangle decorationBounds, Color color)
+			: this(actor.CenterPosition, decorationBounds, color) { }
+
+		public GlobalButtonOrderSelectionBoxAnnotationRenderable(WPos pos, Rectangle decorationBounds, Color color)
+		{
+			this.pos = pos;
+			this.decorationBounds = decorationBounds;
+			this.color = color;
+		}
+
+		public WPos Pos { get { return pos; } }
+
+		public PaletteReference Palette { get { return null; } }
+		public int ZOffset { get { return 0; } }
+		public bool IsDecoration { get { return true; } }
+
+		public IRenderable WithPalette(PaletteReference newPalette) { return this; }
+		public IRenderable WithZOffset(int newOffset) { return this; }
+		public IRenderable OffsetBy(WVec vec) { return new GlobalButtonOrderSelectionBoxAnnotationRenderable(pos + vec, decorationBounds, color); }
+		public IRenderable AsDecoration() { return this; }
+
+		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
+		public void Render(WorldRenderer wr)
+		{
+			var tl = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Left, decorationBounds.Top)).ToFloat2();
+			var br = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Right, decorationBounds.Bottom)).ToFloat2();
+			var tr = new float2(br.X, tl.Y);
+			var bl = new float2(tl.X, br.Y);
+			var u = new float2(6, 0);
+			var v = new float2(0, 6);
+			var u1 = new float2(3, 0);
+			var v1 = new float2(0, 3);
+			float width = 1F;
+
+			var cr = Game.Renderer.RgbaColorRenderer;
+			cr.DrawLine(new float3[] { tl + u, tl, tl + v }, width, color, true);
+			cr.DrawLine(new float3[] { tr - u, tr, tr + v }, width, color, true);
+			cr.DrawLine(new float3[] { br - u, br, br - v }, width, color, true);
+			cr.DrawLine(new float3[] { bl + u, bl, bl - v }, width, color, true);
+
+			cr.DrawLine(new float3[] { tl + u1 + v1, tl }, width, color, true);
+			cr.DrawLine(new float3[] { tr - u1 + v1, tr }, width, color, true);
+			cr.DrawLine(new float3[] { br - u1 - v1, br }, width, color, true);
+			cr.DrawLine(new float3[] { bl + u1 - v1, bl }, width, color, true);
+		}
+
+		public void RenderDebugGeometry(WorldRenderer wr) { }
+		public Rectangle ScreenBounds(WorldRenderer wr) { return Rectangle.Empty; }
+	}
+}

--- a/OpenRA.Mods.Common/Graphics/RectangleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RectangleAnnotationRenderable.cs
@@ -1,0 +1,61 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.Graphics
+{
+	public struct RectangleAnnotationRenderable : IRenderable, IFinalizedRenderable
+	{
+		readonly WPos[] vertices;
+		readonly WPos effectivePos;
+		readonly int width;
+		readonly Color color;
+
+		public RectangleAnnotationRenderable(WPos tl, WPos br, WPos effectivePos, int width, Color color)
+		{
+			vertices = new[] { tl, new WPos(br.X, tl.Y, 0), br, new WPos(tl.X, br.Y, 0) };
+			this.effectivePos = effectivePos;
+			this.width = width;
+			this.color = color;
+		}
+
+		public RectangleAnnotationRenderable(WPos[] vertices, WPos effectivePos, int width, Color color)
+		{
+			this.vertices = vertices;
+			this.effectivePos = effectivePos;
+			this.width = width;
+			this.color = color;
+		}
+
+		public WPos Pos { get { return effectivePos; } }
+		public PaletteReference Palette { get { return null; } }
+		public int ZOffset { get { return 0; } }
+		public bool IsDecoration { get { return true; } }
+
+		public IRenderable WithPalette(PaletteReference newPalette) { return new RectangleAnnotationRenderable(vertices, effectivePos, width, color); }
+		public IRenderable WithZOffset(int newOffset) { return new RectangleAnnotationRenderable(vertices, effectivePos, width, color); }
+		public IRenderable OffsetBy(WVec vec) { return new RectangleAnnotationRenderable(vertices.Select(v => v + vec).ToArray(), effectivePos + vec, width, color); }
+		public IRenderable AsDecoration() { return this; }
+
+		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
+		public void Render(WorldRenderer wr)
+		{
+			var verts = vertices.Select(v => wr.Viewport.WorldToViewPx(wr.ScreenPosition(v)).ToFloat2()).ToArray();
+			Game.Renderer.RgbaColorRenderer.DrawPolygon(verts, width, color);
+		}
+
+		public void RenderDebugGeometry(WorldRenderer wr) { }
+		public Rectangle ScreenBounds(WorldRenderer wr) { return Rectangle.Empty; }
+	}
+}

--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -16,91 +16,35 @@ using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public abstract class GlobalButtonOrderGenerator<T> : OrderGenerator
+	public abstract class GlobalButtonOrderGenerator : IOrderGenerator
 	{
-		string order;
-
-		public GlobalButtonOrderGenerator(string order)
+		public virtual IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
-			this.order = order;
+			if ((mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down) || (mi.Button == MouseButton.Right && mi.Event == MouseInputEvent.Up))
+				return OrderInner(world, cell, worldPixel, mi);
+
+			return Enumerable.Empty<Order>();
 		}
 
-		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
-		{
-			if (mi.Button == MouseButton.Right)
-				world.CancelInputMode();
+		void IOrderGenerator.Tick(World world) { Tick(world); }
+		IEnumerable<IRenderable> IOrderGenerator.Render(WorldRenderer wr, World world) { return Render(wr, world); }
+		IEnumerable<IRenderable> IOrderGenerator.RenderAboveShroud(WorldRenderer wr, World world) { return RenderAboveShroud(wr, world); }
+		IEnumerable<IRenderable> IOrderGenerator.RenderAnnotations(WorldRenderer wr, World world) { return RenderAnnotations(wr, world); }
+		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi) { return GetCursor(world, cell, worldPixel, mi); }
+		void IOrderGenerator.Deactivate() { }
+		bool IOrderGenerator.HandleKeyPress(KeyInput e) { return false; }
 
-			return OrderInner(world, mi);
-		}
-
-		protected virtual bool IsValidTrait(T t)
-		{
-			return Exts.IsTraitEnabled(t);
-		}
-
-		protected IEnumerable<Order> OrderInner(World world, MouseInput mi)
-		{
-			if (mi.Button == MouseButton.Left)
-			{
-				var underCursor = world.ScreenMap.ActorsAtMouse(mi)
-					.Select(a => a.Actor)
-					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.TraitsImplementing<T>()
-						.Any(IsValidTrait));
-
-				if (underCursor == null)
-					yield break;
-
-				yield return new Order(order, underCursor, false);
-			}
-		}
-
-		protected override void Tick(World world)
+		protected virtual void Tick(World world)
 		{
 			if (world.LocalPlayer != null &&
 				world.LocalPlayer.WinState != WinState.Undefined)
 				world.CancelInputMode();
 		}
 
-		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
-		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
-
-		protected abstract override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi);
-	}
-
-	public class PowerDownOrderGenerator : GlobalButtonOrderGenerator<ToggleConditionOnOrder>
-	{
-		public PowerDownOrderGenerator()
-			: base("PowerDown") { }
-
-		protected override bool IsValidTrait(ToggleConditionOnOrder t)
-		{
-			return !t.IsTraitDisabled && !t.IsTraitPaused;
-		}
-
-		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
-		{
-			mi.Button = MouseButton.Left;
-			return OrderInner(world, mi).Any() ? "powerdown" : "powerdown-blocked";
-		}
-	}
-
-	public class SellOrderGenerator : GlobalButtonOrderGenerator<Sellable>
-	{
-		public SellOrderGenerator()
-			: base("Sell") { }
-
-		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
-		{
-			mi.Button = MouseButton.Left;
-
-			var cursor = OrderInner(world, mi)
-				.SelectMany(o => o.Subject.TraitsImplementing<Sellable>())
-				.Where(Exts.IsTraitEnabled)
-				.Select(si => si.Info.Cursor)
-				.FirstOrDefault();
-
-			return cursor ?? "sell-blocked";
-		}
+		protected virtual IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
+		protected virtual IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		protected virtual IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
+		protected abstract string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi);
+		protected abstract IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi);
 	}
 }

--- a/OpenRA.Mods.Common/Orders/PowerDownOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PowerDownOrderGenerator.cs
@@ -1,0 +1,216 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Orders
+{
+	class PowerDownOrderGenerator : GlobalButtonOrderGenerator
+	{
+		int2 dragStartMousePos;
+		int2 dragEndMousePos;
+		bool isDragging;
+
+		public override IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			if ((mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down) || (mi.Button == MouseButton.Right && mi.Event == MouseInputEvent.Up) || (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Up) || (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Move))
+				return OrderInner(world, cell, worldPixel, mi);
+
+			return Enumerable.Empty<Order>();
+		}
+
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			if (mi.Button == MouseButton.Right)
+				world.CancelInputMode();
+
+			return OrderInner(world, mi, worldPixel);
+		}
+
+		protected IEnumerable<Order> OrderInner(World world, MouseInput mi, int2 worldPixel)
+		{
+			if (mi.Button != MouseButton.Left)
+				yield break;
+
+			dragEndMousePos = worldPixel;
+
+			if (mi.Event == MouseInputEvent.Down)
+			{
+				if (!isDragging)
+				{
+					isDragging = true;
+					dragStartMousePos = worldPixel;
+				}
+
+				yield break;
+			}
+
+			if (mi.Event == MouseInputEvent.Move)
+				yield break;
+
+			// Use "isDragging" here to avoid mis-dragging when player use hot key to switch mode.
+			if (isDragging && mi.Event == MouseInputEvent.Up)
+			{
+				var actors = SelectToggleConditionActorsInBoxWithDeadzone(world, dragStartMousePos, dragEndMousePos, mi.Modifiers);
+
+				isDragging = false;
+
+				if (!actors.Any())
+					yield break;
+
+				foreach (var actor in actors)
+					yield return new Order("PowerDown", actor, false);
+			}
+		}
+
+		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world)
+		{
+			var lastMousePos = wr.Viewport.ViewToWorldPx(Viewport.LastMousePos);
+			if (isDragging && (lastMousePos - dragStartMousePos).Length > Game.Settings.Game.SelectionDeadzone)
+			{
+				var diag1 = wr.ProjectedPosition(lastMousePos);
+				var diag2 = wr.ProjectedPosition(dragStartMousePos);
+				var modifiers = Game.GetModifierKeys();
+
+				// Draw the rectangle box dragged by mouse.
+				yield return new RectangleAnnotationRenderable(diag1, diag2, diag1, 1, Color.Yellow);
+
+				/* Following code do two things:
+				// 1. Draw health bar for every units/buildings can be power-down inside the box.
+				// 2. Draw highlight box for each unit/building that can be power-down inside the box.
+				*/
+				var actors = SelectToggleConditionActorsInBoxWithDeadzone(world, dragStartMousePos, lastMousePos, modifiers, true);
+				foreach (var actor in actors)
+				{
+					var decorationBounds = actor.TraitsImplementing<IDecorationBounds>().ToArray();
+					var bounds = decorationBounds.FirstNonEmptyBounds(actor, wr);
+
+					yield return new SelectionBarsAnnotationRenderable(actor, bounds, true, false);
+					yield return new GlobalButtonOrderSelectionBoxAnnotationRenderable(actor, bounds, Color.Orange);
+				}
+			}
+
+			yield break;
+		}
+
+		protected IEnumerable<Actor> SelectToggleConditionActorsInBoxWithDeadzone(World world, int2 a, int2 b, Modifiers modifiers, bool forRendering = false)
+		{
+			// Because the "WorldInteractionControllerWidget" can show detailed unit's information when mouse over,
+			// so we can just leave it alone when render under cursor actor. No needs to render it twice.
+			var isDeadzone = true;
+			if ((a - b).Length <= Game.Settings.Game.SelectionDeadzone)
+			{
+				if (forRendering)
+					return Enumerable.Empty<Actor>();
+				else
+					isDeadzone = false;
+			}
+
+			IEnumerable<Actor> allActors;
+
+			if (isDeadzone)
+			{
+				// "x.AppearsFriendlyTo(world.LocalPlayer.PlayerActor)" only select local player and allied units.
+				// "x.Owner == world.LocalPlayer" only select local player units which is from local player and allied,
+				// when used with the line above.
+				allActors = world.ScreenMap.ActorsInMouseBox(a, b)
+					.Select(x => x.Actor)
+					.Where(x => x.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) && x.Owner == world.LocalPlayer && !world.FogObscures(x)
+						&& x.TraitsImplementing<ToggleConditionOnOrder>().Any(IsValidTrait));
+
+				if (!allActors.Any())
+					return allActors;
+			}
+			else
+			{
+				allActors = world.ScreenMap.ActorsAtMouse(b)
+					.Select(x => x.Actor)
+					.Where(x => x.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) && x.Owner == world.LocalPlayer && !world.FogObscures(x)
+						&& x.TraitsImplementing<ToggleConditionOnOrder>().Any(IsValidTrait));
+				return allActors;
+			}
+
+			if (forRendering)
+			{
+				allActors = allActors
+					.Select(x => x)
+					.Where(x => x.TraitOrDefault<ISelectionDecorations>() != null);
+			}
+
+			/* Modifiers for Powerdown Mode
+			// Default: generally turn on/off with smart selection.
+			// Ctrl: Only turn off.
+			// Alt: Only turn on.
+			*/
+			if (modifiers == Modifiers.Ctrl)
+			{
+				return allActors = allActors
+						.Select(x => x)
+						.Where(x => !x.Trait<ToggleConditionOnOrder>().IsEnabled());
+			}
+			else if (modifiers == Modifiers.Alt)
+			{
+				return allActors = allActors
+						.Select(x => x)
+						.Where(x => x.Trait<ToggleConditionOnOrder>().IsEnabled());
+			}
+
+			// Default modifier:
+			else
+			{
+				/* Smart Selection of Buildings: at first, check power-down status of things inside,
+				// then either select those who are not power-down or select all whose power-down status are actived.
+				*/
+				if (!allActors.All(x => x.Trait<ToggleConditionOnOrder>().IsEnabled()))
+				{
+					return allActors
+						.Select(x => x)
+						.Where(x => !x.Trait<ToggleConditionOnOrder>().IsEnabled());
+				}
+
+				return allActors;
+			}
+		}
+
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			// "x.Info.HasTraitInfo<SelectableInfo>()" avoids selecting some special actors like "camera" and "mutiplayer starting point".
+			var underCursor = world.ScreenMap.ActorsAtMouse(worldPixel)
+					.Select(x => x.Actor)
+					.Where(x => x.Info.HasTraitInfo<SelectableInfo>() && !world.FogObscures(x));
+
+			// ONLY when the mouse is over an enemy/allied/powerdown-blocked and selectable actor, the cursor will change to "powerdown-blocked",
+			// which means cursor is "powerdown" when no normal actors under the mouse.
+			if (!underCursor.Any())
+				return "powerdown";
+			else
+			{
+				var actor = underCursor.First();
+				if (actor.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) && actor.Owner == world.LocalPlayer
+						&& actor.TraitsImplementing<ToggleConditionOnOrder>().Any(IsValidTrait))
+					return "powerdown";
+				else
+					return "powerdown-blocked";
+			}
+		}
+
+		protected bool IsValidTrait(ToggleConditionOnOrder t)
+		{
+			return !t.IsTraitDisabled && !t.IsTraitPaused;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -12,86 +12,302 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public class RepairOrderGenerator : OrderGenerator
+	public class RepairOrderGenerator : GlobalButtonOrderGenerator
 	{
+		int2 dragStartMousePos;
+		int2 dragEndMousePos;
+		bool isDragging;
+
+		public override IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			if ((mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down) || (mi.Button == MouseButton.Right && mi.Event == MouseInputEvent.Up) || (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Up) || (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Move))
+				return OrderInner(world, cell, worldPixel, mi);
+
+			return Enumerable.Empty<Order>();
+		}
+
 		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			if (mi.Button == MouseButton.Right)
 				world.CancelInputMode();
 
-			return OrderInner(world, mi);
+			return OrderInner(world, mi, worldPixel);
 		}
 
-		static IEnumerable<Order> OrderInner(World world, MouseInput mi)
+		protected IEnumerable<Order> OrderInner(World world, MouseInput mi, int2 worldPixel)
 		{
 			if (mi.Button != MouseButton.Left)
 				yield break;
 
-			var underCursor = world.ScreenMap.ActorsAtMouse(mi)
-				.Select(a => a.Actor)
-				.FirstOrDefault(a => a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) && !world.FogObscures(a));
+			dragEndMousePos = worldPixel;
 
-			if (underCursor == null)
+			if (mi.Event == MouseInputEvent.Down)
+			{
+				if (!isDragging)
+				{
+					isDragging = true;
+					dragStartMousePos = worldPixel;
+				}
+
+				yield break;
+			}
+
+			if (mi.Event == MouseInputEvent.Move)
 				yield break;
 
-			if (underCursor.GetDamageState() == DamageState.Undamaged)
-				yield break;
+			// Use "isDragging" here to avoid mis-dragging when player use hot key to switch mode.
+			if (isDragging && mi.Event == MouseInputEvent.Up)
+			{
+				var actors = SelectRepairableActorsInBoxWithDeadzone(world, dragStartMousePos, dragEndMousePos, mi.Modifiers);
+				isDragging = false;
 
+				if (!actors.Any())
+					yield break;
+
+				foreach (var actor in actors)
+					yield return RepairUnderCondition(actor, world, mi);
+			}
+		}
+
+		protected Order RepairUnderCondition(Actor actor, World world, MouseInput mi)
+		{
 			// Repair a building.
-			if (underCursor.Info.HasTraitInfo<RepairableBuildingInfo>())
-				yield return new Order("RepairBuilding", world.LocalPlayer.PlayerActor, Target.FromActor(underCursor), false);
-
-			// Don't command allied units
-			if (underCursor.Owner != world.LocalPlayer)
-				yield break;
+			if (actor.Info.HasTraitInfo<RepairableBuildingInfo>())
+			{
+				return new Order("RepairBuilding", world.LocalPlayer.PlayerActor, Target.FromActor(actor), false)
+				{
+					SuppressVisualFeedback = true
+				};
+			}
 
 			Actor repairBuilding = null;
 			var orderId = "Repair";
 
-			// Test for generic Repairable (used on units).
-			var repairable = underCursor.TraitOrDefault<Repairable>();
+			// Repair units.
+			var repairable = actor.TraitOrDefault<Repairable>();
 			if (repairable != null)
-				repairBuilding = repairable.FindRepairBuilding(underCursor);
+				repairBuilding = repairable.FindRepairBuilding(actor);
 			else
 			{
-				var repairableNear = underCursor.TraitOrDefault<RepairableNear>();
+				var repairableNear = actor.TraitOrDefault<RepairableNear>();
 				if (repairableNear != null)
 				{
 					orderId = "RepairNear";
-					repairBuilding = repairableNear.FindRepairBuilding(underCursor);
+					repairBuilding = repairableNear.FindRepairBuilding(actor);
 				}
 			}
 
-			if (repairBuilding == null)
-				yield break;
-
-			yield return new Order(orderId, underCursor, Target.FromActor(repairBuilding), mi.Modifiers.HasModifier(Modifiers.Shift))
+			return new Order(orderId, actor, Target.FromActor(repairBuilding), mi.Modifiers.HasModifier(Modifiers.Shift))
 			{
-				VisualFeedbackTarget = Target.FromActor(underCursor)
+				VisualFeedbackTarget = Target.FromActor(actor),
+				SuppressVisualFeedback = true
 			};
 		}
 
-		protected override void Tick(World world)
+		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world)
 		{
-			if (world.LocalPlayer != null &&
-				world.LocalPlayer.WinState != WinState.Undefined)
-				world.CancelInputMode();
+			var lastMousePos = wr.Viewport.ViewToWorldPx(Viewport.LastMousePos);
+			if (isDragging && (lastMousePos - dragStartMousePos).Length > Game.Settings.Game.SelectionDeadzone)
+			{
+				var diag1 = wr.ProjectedPosition(lastMousePos);
+				var diag2 = wr.ProjectedPosition(dragStartMousePos);
+				var modifiers = Game.GetModifierKeys();
+
+				// Draw the rectangle box dragged by mouse.
+				yield return new RectangleAnnotationRenderable(diag1, diag2, diag1, 1, Color.FromArgb(0xff009a00));
+
+				/* Following codes do two things:
+				// 1. Draw health bar for every repairable units/buildings that can be repaired inside the box under modifier.
+				// 2. Draw highlight box for each unit/building that can be repaired inside the box under modifier.
+				*/
+				var actors = SelectRepairableActorsInBoxWithDeadzone(world, dragStartMousePos, lastMousePos, modifiers, true);
+				foreach (var actor in actors)
+				{
+					var decorationBounds = actor.TraitsImplementing<IDecorationBounds>().ToArray();
+					var bounds = decorationBounds.FirstNonEmptyBounds(actor, wr);
+					yield return new SelectionBarsAnnotationRenderable(actor, bounds, true, false);
+					yield return new GlobalButtonOrderSelectionBoxAnnotationRenderable(actor, bounds, Color.FromArgb(0xff00ea00));
+				}
+			}
+
+			yield break;
 		}
 
-		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
-		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
+		protected bool CheckRepairable(Actor actor, World world)
+		{
+			if (actor.GetDamageState() == DamageState.Undamaged)
+				return false;
+
+			// 1. Test for buildings repairable.
+			if (actor.Info.HasTraitInfo<RepairableBuildingInfo>())
+				return true;
+
+			// 2. Test for generic repairable (used on units).
+			// Player can only repair their own units. Unlike buildings.
+			if (actor.Owner != world.LocalPlayer)
+				return false;
+
+			Actor repairBuilding = null;
+
+			var repairable = actor.TraitOrDefault<Repairable>();
+			if (repairable != null)
+				repairBuilding = repairable.FindRepairBuilding(actor);
+			else
+			{
+				var repairableNear = actor.TraitOrDefault<RepairableNear>();
+				if (repairableNear != null)
+				{
+					repairBuilding = repairableNear.FindRepairBuilding(actor);
+				}
+			}
+
+			if (repairBuilding != null)
+				return true;
+
+			return false;
+		}
+
+		protected IEnumerable<Actor> SelectRepairableActorsInBoxWithDeadzone(World world, int2 a, int2 b, Modifiers modifiers, bool forRendering = false)
+		{
+			// Because the "WorldInteractionControllerWidget" can show detailed unit's information when mouse over,
+			// so we can just leave it alone when render under cursor actor. No needs to rend it twice.
+			var isDeadzone = true;
+			if ((a - b).Length <= Game.Settings.Game.SelectionDeadzone)
+			{
+				if (forRendering)
+					return Enumerable.Empty<Actor>();
+				else
+					isDeadzone = false;
+			}
+
+			IEnumerable<Actor> allActors;
+
+			if (isDeadzone)
+			{
+				// "x.AppearsFriendlyTo(world.LocalPlayer.PlayerActor)" only select local player and allied units.
+				// "x.Owner == world.LocalPlayer" only select local player units which are from local player and allied
+				// when used with the line above.
+				allActors = world.ScreenMap.ActorsInMouseBox(a, b)
+				.Select(x => x.Actor)
+				.Where(x => x.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) && !world.FogObscures(x)
+					&& CheckRepairable(x, world));
+
+				if (!allActors.Any())
+					return allActors;
+
+				/* Smart Selection Of Buildings: at first, check repairing-status of things inside,
+				// then either select those who not active or select all whose repairing-status are actived.
+				// Because players can repair allies's buildings, so must preprocess here to
+				// get Allies' buildings in lowest priority.
+				*/
+
+				// Preprocess:
+				if (modifiers != Modifiers.Ctrl)
+				{
+					if (!allActors.All(x => x.Owner == world.LocalPlayer))
+					{
+						if (!allActors.All(x => x.Owner != world.LocalPlayer))
+						{
+							allActors = allActors
+							.Select(x => x)
+							.Where(x => !x.Info.HasTraitInfo<RepairableBuildingInfo>() || x.Owner == world.LocalPlayer);
+						}
+					}
+				}
+
+				// Smart select building part
+				if (!allActors.All(x => !x.Info.HasTraitInfo<RepairableBuildingInfo>() || x.Trait<RepairableBuilding>().RepairActive))
+				{
+					allActors = allActors
+						.Select(x => x)
+						.Where(x => !x.Info.HasTraitInfo<RepairableBuildingInfo>() || !x.Trait<RepairableBuilding>().RepairActive);
+				}
+			}
+
+			// When "isDeadzone == false", only choose one or no actor.
+			// No more annoying things like Smart Selection or Repair Selection Priority.
+			else
+			{
+				allActors = world.ScreenMap.ActorsAtMouse(b)
+				.Select(x => x.Actor)
+				.Where(x => x.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) && !world.FogObscures(x)
+					&& CheckRepairable(x, world));
+
+				return allActors;
+			}
+
+			if (forRendering)
+			{
+				allActors = allActors
+							.Select(x => x)
+							.Where(x => x.TraitOrDefault<ISelectionDecorations>() != null);
+			}
+
+			/* Repair Selection Priority:
+			// Default: buildings > combat vehicles and aircrafts > non-combat vehicles and aircrafts > allied buildings
+			// Ctrl: all
+			// Alt: combat vehicles and aircrafts > non-combat vehicles and aircrafts > buildings > allied buildings
+			*/
+			if (modifiers == Modifiers.Ctrl)
+			{
+				return allActors;
+			}
+			else if (modifiers == Modifiers.Alt)
+			{
+				var repairableBuildings = allActors
+						.Select(x => x)
+						.Where(x => !x.Info.HasTraitInfo<RepairableBuildingInfo>())
+						.SubsetWithHighestSelectionPriority(Modifiers.None);
+				if (!repairableBuildings.Any())
+					return allActors;
+				return repairableBuildings;
+			}
+
+			// Default modifier:
+			else
+			{
+				var ownerRepairableBuildings = allActors
+						.Select(x => x)
+						.Where(x => x.Info.HasTraitInfo<RepairableBuildingInfo>() && x.Owner == world.LocalPlayer);
+				if (!ownerRepairableBuildings.Any())
+				{
+					return allActors
+						.Select(x => x)
+						.SubsetWithHighestSelectionPriority(Modifiers.None);
+				}
+
+				return ownerRepairableBuildings;
+			}
+		}
 
 		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
-			mi.Button = MouseButton.Left;
-			return OrderInner(world, mi).Any()
-				? "repair" : "repair-blocked";
+			return MouseOverActor(world, worldPixel) ? "repair" : "repair-blocked";
+		}
+
+		protected bool MouseOverActor(World world, int2 worldPixel)
+		{
+			// "x.Info.HasTraitInfo<SelectableInfo>()" avoids selecting some special actors like "camera" and "mutiplayer starting point".
+			var underCursor = world.ScreenMap.ActorsAtMouse(worldPixel)
+				.Select(x => x.Actor)
+				.Where(x => x.Info.HasTraitInfo<SelectableInfo>() && !world.FogObscures(x));
+
+			// ONLY when the mouse is over an enemy/unrepairable/non-allied-building and selectable actor, the cursor will change to "repair-blocked",
+			// which means cursor is "repair" when no normal actors under the mouse.
+			if (!underCursor.Any())
+				return true;
+			else
+			{
+				var actor = underCursor.First();
+				return actor.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) && CheckRepairable(actor, world);
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Orders/SellOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/SellOrderGenerator.cs
@@ -1,0 +1,71 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+# endregion
+ 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenRA.Mods.Common.Traits;
+
+namespace OpenRA.Mods.Common.Orders
+{
+	class SellOrderGenerator : GlobalButtonOrderGenerator
+	{
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			if (mi.Button == MouseButton.Right)
+				world.CancelInputMode();
+
+			return OrderInner(world, mi);
+		}
+
+		protected IEnumerable<Order> OrderInner(World world, MouseInput mi)
+		{
+			if (mi.Button == MouseButton.Left)
+			{
+				// This one is regular function just like classical C&C. No dragging function for this.
+				// Just keep in mind that some unselectable\fog-obscured things can be sell.
+				// For example: walls
+				var actor = world.ScreenMap.ActorsAtMouse(mi)
+					.Select(a => a.Actor)
+					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor)
+						&& a.TraitsImplementing<Sellable>().Any(IsValidTrait));
+
+				if (actor == null)
+					yield break;
+
+				yield return new Order("Sell", actor, false);
+			}
+		}
+
+		protected bool IsValidTrait(Sellable t)
+		{
+			return Exts.IsTraitEnabled(t);
+		}
+
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			var underCursor = world.ScreenMap.ActorsAtMouse(mi)
+					.Select(a => a.Actor)
+					.Where(a => a.Owner == world.LocalPlayer && a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor)
+						&& a.TraitsImplementing<Sellable>().Any(IsValidTrait));
+
+			// This cursor is using regular rules just like classical C&C.
+			// Just keep in mind that some unselectable\fog-obscured things can be sell.
+			// For example: walls
+			if (underCursor.Any())
+				return "sell";
+			else
+				return "sell-blocked";
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
@@ -52,6 +52,11 @@ namespace OpenRA.Mods.Common.Traits
 		public ToggleConditionOnOrder(Actor self, ToggleConditionOnOrderInfo info)
 			: base(info) { }
 
+		public bool IsEnabled()
+		{
+			return enabled;
+		}
+
 		protected override void Created(Actor self)
 		{
 			base.Created(self);


### PR DESCRIPTION
Allow players to drag a box to repair and offline/online buildings and units and good virtual effect related, as well as **original function of clicking is the same as before.** 

Make that little wrench and tiny spark more convenient and helpful to players! Now you can:

1. Box drag to repair! **Smart drag for buildings!**
-- Default:  buildings prior repairing.
-- Alt: vehicles and aircrafts prior repairing.
-- Ctrl: all repairing.

In game:
![repair](https://user-images.githubusercontent.com/13763394/74159407-b709e980-4c56-11ea-87ea-be9f28c54655.gif)
(The [flash bug](https://github.com/OpenRA/OpenRA/pull/17477#issuecomment-583297874) in GIF is fixed in current version)
![repair2](https://user-images.githubusercontent.com/13763394/74159418-ba9d7080-4c56-11ea-8aae-38ce164e6cac.gif)

2. Box drag to powedown! 
-- Default: generally turn on/off with  **Smart drag!**
-- Ctrl: Only turn off.
-- Alt: Only turn on.

In game:
![power](https://user-images.githubusercontent.com/13763394/74159362-9e99cf00-4c56-11ea-848b-446e5df08522.gif)

---------------------------------------
For devs who dare to use this controversial function, here is more details!

Repair Box Dragging Selection Priority and Modifiers mode(smart selection for building only):
-- Default: buildings > combat vehicles and aircrafts > non-combat vehicles and aircrafts > allied buildings
-- Ctrl: all
-- Alt: combat vehicles and aircrafts > non-combat vehicles and aircrafts > buildings > allied buildings

This idea can also help to solve problem like small buildings hard to repair due to their image mixed up with each other like most of T1 defence, as well as help pick out the damaged fix-wings airborne units when they are circling. 