### PR TITLE
AI over fix -- engine only edition

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/PowerDownBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/PowerDownBotModule.cs
@@ -1,0 +1,152 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Manages AI powerdown.")]
+	public class PowerDownBotModuleInfo : ConditionalTraitInfo
+	{
+		[Desc("Delay (in ticks) between toggling powerdown")]
+		public readonly int Interval = 150;
+
+		public override object Create(ActorInitializer init) { return new PowerDownBotModule(init.Self, this); }
+	}
+
+	public class PowerDownBotModule : ConditionalTrait<PowerDownBotModuleInfo>, IBotTick
+	{
+		readonly World world;
+		readonly Player player;
+		PowerManager playerPower;
+		int toggleTick;
+		readonly Func<Actor, bool> isToggledBuildingsValid;
+		List<BuildingPowerWrapper> toggledBuildings;
+
+		class BuildingPowerWrapper
+		{
+			public int PowerChanging;
+			public Actor Actor;
+
+			public BuildingPowerWrapper(Actor a, int p)
+			{
+				Actor = a;
+				PowerChanging = p;
+			}
+		}
+
+		public PowerDownBotModule(Actor self, PowerDownBotModuleInfo info)
+			: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+			toggledBuildings = new List<BuildingPowerWrapper>();
+			isToggledBuildingsValid = a => a.Owner == self.Owner && !a.IsDead && a.IsInWorld && GetTogglePowerChanging(a) < 0;
+		}
+
+		protected override void Created(Actor self)
+		{
+			// Special case handling is required for the Player actor.
+			// Created is called before Player.PlayerActor is assigned,
+			// so we must query player traits from self, which refers
+			// for bot modules always to the Player actor.
+			playerPower = self.TraitOrDefault<PowerManager>();
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			toggleTick = world.LocalRandom.Next(0, Info.Interval);
+			toggledBuildings = new List<BuildingPowerWrapper>();
+		}
+
+		int GetTogglePowerChanging(Actor a)
+		{
+			var powerChangingIfToggled = 0;
+			var powerTarit = a.TraitsImplementing<Power>().Where(t => !t.IsTraitDisabled).ToArray();
+			var powerMulTrait = a.TraitsImplementing<PowerMultiplier>().ToArray();
+			if (powerTarit.Any())
+			{
+				powerChangingIfToggled = powerTarit.Sum(p => p.Info.Amount) * (powerMulTrait.Sum(p => p.Info.Modifier) - 100) / 100;
+				if (powerMulTrait.Where(t => !t.IsTraitDisabled).Any())
+					powerChangingIfToggled = -powerChangingIfToggled;
+			}
+
+			return powerChangingIfToggled;
+		}
+
+		IEnumerable<Actor> GetToggleableBuildings(IBot bot)
+		{
+			var toggleable = bot.Player.World.ActorsHavingTrait<ToggleConditionOnOrder>(t => !t.IsTraitDisabled && !t.IsTraitPaused)
+				.Where(a => a != null && !a.IsDead && a.Owner == player && a.Info.HasTraitInfo<PowerInfo>() && a.Info.HasTraitInfo<PowerMultiplierInfo>() && a.Info.HasTraitInfo<BuildingInfo>());
+
+			return toggleable;
+		}
+
+		IEnumerable<BuildingPowerWrapper> GetOnlineBuildings(IBot bot)
+		{
+			List<BuildingPowerWrapper> toggleableBuilding = new List<BuildingPowerWrapper>();
+
+			foreach (var a in GetToggleableBuildings(bot))
+			{
+				var powerChanging = GetTogglePowerChanging(a);
+				if (powerChanging > 0)
+					toggleableBuilding.Add(new BuildingPowerWrapper(a, powerChanging));
+			}
+
+			return toggleableBuilding.OrderBy(bpw => bpw.PowerChanging);
+		}
+
+		public void BotTick(IBot bot)
+		{
+			if (toggleTick > 0 || playerPower == null)
+			{
+				toggleTick--;
+				return;
+			}
+
+			var power = playerPower.ExcessPower;
+			toggledBuildings = toggledBuildings.Where(bpw => isToggledBuildingsValid(bpw.Actor)).OrderByDescending(bpw => bpw.PowerChanging).ToList();
+
+			// When there is extra power, check if AI can toggle on
+			if (power > 0)
+			{
+				foreach (var bpw in toggledBuildings)
+				{
+					if (power + bpw.PowerChanging < 0)
+						continue;
+
+					bot.QueueOrder(new Order("PowerDown", bpw.Actor, false));
+					power += bpw.PowerChanging;
+				}
+			}
+
+			// When there is no power, check if AI can toggle off
+			else if (power < 0)
+			{
+				var buildingsCanBeOff = GetOnlineBuildings(bot);
+				foreach (var bpw in buildingsCanBeOff)
+				{
+					if (power > 0)
+						break;
+
+					bot.QueueOrder(new Order("PowerDown", bpw.Actor, false));
+					toggledBuildings.Add(new BuildingPowerWrapper(bpw.Actor, -bpw.PowerChanging));
+					power += bpw.PowerChanging;
+				}
+			}
+
+			toggleTick = Info.Interval;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -10,11 +10,10 @@
 #endregion
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits.BotModules.Squads;
-using OpenRA.Support;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -74,7 +73,16 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Radius in cells that protecting squads should scan for enemies around their position.")]
 		public readonly int ProtectionScanRadius = 8;
 
+		[Desc("Enemy target types to never target.")]
+		public readonly BitSet<TargetableType> IgnoredEnemyTargetTypes = default(BitSet<TargetableType>);
 		public override object Create(ActorInitializer init) { return new SquadManagerBotModule(init.Self, this); }
+
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			base.RulesetLoaded(rules, ai);
+			if (DangerScanRadius <= 0)
+				throw new YamlException("DangerScanRadius must be greater than zero.");
+		}
 	}
 
 	public class SquadManagerBotModule : ConditionalTrait<SquadManagerBotModuleInfo>, IBotEnabled, IBotTick, IBotRespondToAttack, IBotPositionsUpdated, IGameSaveTraitData
@@ -119,11 +127,28 @@ namespace OpenRA.Mods.Common.Traits
 			unitCannotBeOrdered = a => a == null || a.Owner != Player || a.IsDead || !a.IsInWorld;
 		}
 
-		public bool IsEnemyUnit(Actor a)
+		public bool IsPreferredEnemyUnit(Actor a)
 		{
-			return a != null && !a.IsDead && Player.Stances[a.Owner] == Stance.Enemy
-				&& !a.Info.HasTraitInfo<HuskInfo>()
-				&& !a.GetEnabledTargetTypes().IsEmpty;
+			if (a == null || a.IsDead || Player.Stances[a.Owner] != Stance.Enemy || a.Info.HasTraitInfo<HuskInfo>())
+				return false;
+
+			var targetTypes = a.GetEnabledTargetTypes();
+			return !targetTypes.IsEmpty && !targetTypes.Overlaps(Info.IgnoredEnemyTargetTypes);
+		}
+
+		public bool IsNotHiddenUnit(Actor a)
+		{
+			var hasModifier = false;
+			var visModifiers = a.TraitsImplementing<IVisibilityModifier>();
+			foreach (var v in visModifiers)
+			{
+				if (v.IsVisible(a, Player))
+					return true;
+
+				hasModifier = true;
+			}
+
+			return !hasModifier;
 		}
 
 		protected override void TraitEnabled(Actor self)
@@ -153,12 +178,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		internal Actor FindClosestEnemy(WPos pos)
 		{
-			return World.Actors.Where(IsEnemyUnit).ClosestTo(pos);
+			var units = World.Actors.Where(IsPreferredEnemyUnit);
+			return units.Where(IsNotHiddenUnit).ClosestTo(pos) ?? units.ClosestTo(pos);
 		}
 
 		internal Actor FindClosestEnemy(WPos pos, WDist radius)
 		{
-			return World.FindActorsInCircle(pos, radius).Where(IsEnemyUnit).ClosestTo(pos);
+			return World.FindActorsInCircle(pos, radius).Where(a => IsPreferredEnemyUnit(a) && IsNotHiddenUnit(a)).ClosestTo(pos);
 		}
 
 		void CleanSquads()
@@ -288,7 +314,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				// Don't rush enemy aircraft!
 				var enemies = World.FindActorsInCircle(b.CenterPosition, WDist.FromCells(Info.RushAttackScanRadius))
-					.Where(unit => IsEnemyUnit(unit) && unit.Info.HasTraitInfo<AttackBaseInfo>() && !unit.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(unit.Info.Name)).ToList();
+					.Where(unit => IsPreferredEnemyUnit(unit) && unit.Info.HasTraitInfo<AttackBaseInfo>() && !unit.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(unit.Info.Name)).ToList();
 
 				if (AttackOrFleeFuzzy.Rush.CanAttack(ownUnits, enemies))
 				{
@@ -334,7 +360,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
 		{
-			if (!IsEnemyUnit(e.Attacker))
+			if (!IsPreferredEnemyUnit(e.Attacker))
 				return;
 
 			// Protected priority assets, MCVs, harvesters and buildings

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -300,35 +300,27 @@ namespace OpenRA.Mods.Common.Traits
 
 		void TryToRushAttack(IBot bot)
 		{
-			var allEnemyBaseBuilder = AIUtils.FindEnemiesByCommonName(Info.ConstructionYardTypes, Player);
+			// Note that Rush Squad is almost the same as Assuslt Squad at present.
+			// The meaning of this squad now is not rushing everything to a basebuilder with bugs,
+			// instead, it keeps two squads at bay which is isolated to each other for a bot player,
+			// and performance friendly, while Rush Squad tend to aimming at basebuilder.
+			var randomizedSquadSize = Info.SquadSize + World.LocalRandom.Next(Info.SquadSizeRandomBonus);
 
-			// TODO: This should use common names & ExcludeFromSquads instead of hardcoding TraitInfo checks
-			var ownUnits = activeUnits
-				.Where(unit => unit.IsIdle && unit.Info.HasTraitInfo<AttackBaseInfo>()
-					&& !unit.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(unit.Info.Name) && !unit.Info.HasTraitInfo<HarvesterInfo>()).ToList();
-
-			if (!allEnemyBaseBuilder.Any() || ownUnits.Count < Info.SquadSize)
+			if (unitsHangingAroundTheBase.Count < randomizedSquadSize)
 				return;
 
-			foreach (var b in allEnemyBaseBuilder)
-			{
-				// Don't rush enemy aircraft!
-				var enemies = World.FindActorsInCircle(b.CenterPosition, WDist.FromCells(Info.RushAttackScanRadius))
-					.Where(unit => IsPreferredEnemyUnit(unit) && unit.Info.HasTraitInfo<AttackBaseInfo>() && !unit.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(unit.Info.Name)).ToList();
+			var attackForce = RegisterNewSquad(bot, SquadType.Rush);
 
-				if (AttackOrFleeFuzzy.Rush.CanAttack(ownUnits, enemies))
-				{
-					var target = enemies.Any() ? enemies.Random(World.LocalRandom) : b;
-					var rush = GetSquadOfType(SquadType.Rush);
-					if (rush == null)
-						rush = RegisterNewSquad(bot, SquadType.Rush, target);
+			foreach (var a in unitsHangingAroundTheBase)
+				if (!a.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(a.Info.Name))
+					attackForce.Units.Add(a);
 
-					foreach (var a3 in ownUnits)
-						rush.Units.Add(a3);
+			var enemybase = AIUtils.FindEnemiesByCommonName(Info.ConstructionYardTypes, Player).Random(World.LocalRandom);
+			attackForce.TargetActor = enemybase;
 
-					return;
-				}
-			}
+			unitsHangingAroundTheBase.Clear();
+			foreach (var n in notifyIdleBaseUnits)
+				n.UpdatedIdleBaseUnits(unitsHangingAroundTheBase);
 		}
 
 		void ProtectOwn(IBot bot, Actor attacker)

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.BotModules.Squads
@@ -71,10 +72,13 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			}
 
 			var enemyUnits = owner.World.FindActorsInCircle(owner.TargetActor.CenterPosition, WDist.FromCells(owner.SquadManager.Info.IdleScanRadius))
-				.Where(owner.SquadManager.IsEnemyUnit).ToList();
+				.Where(a => owner.SquadManager.IsPreferredEnemyUnit(a) && owner.SquadManager.IsNotHiddenUnit(a)).ToList();
 
 			if (enemyUnits.Count == 0)
+			{
+				Retreat(owner, false, true, true);
 				return;
+			}
 
 			if (AttackOrFleeFuzzy.Default.CanAttack(owner.Units, enemyUnits))
 			{
@@ -130,7 +134,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			else
 			{
 				var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.SquadManager.Info.AttackScanRadius))
-					.Where(owner.SquadManager.IsEnemyUnit);
+					.Where(a => owner.SquadManager.IsPreferredEnemyUnit(a) && owner.SquadManager.IsNotHiddenUnit(a));
 				var target = enemies.ClosestTo(leader.CenterPosition);
 				if (target != null)
 				{
@@ -190,7 +194,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!owner.IsValid)
 				return;
 
-			GoToRandomOwnBuilding(owner);
+			Retreat(owner, true, true, true);
 			owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsIdleState(), true);
 		}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -95,11 +95,128 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				if (u.Owner == squad.Bot.Player && u.Info.HasTraitInfo<BuildingInfo>())
 					return false;
 
-			var enemyAroundUnit = units.Where(unit => squad.SquadManager.IsEnemyUnit(unit) && unit.Info.HasTraitInfo<AttackBaseInfo>());
+			var enemyAroundUnit = units.Where(unit => squad.SquadManager.IsPreferredEnemyUnit(unit) && unit.Info.HasTraitInfo<AttackBaseInfo>());
 			if (!enemyAroundUnit.Any())
 				return false;
 
 			return flee(enemyAroundUnit);
+		}
+
+		protected static bool IsRearming(Actor a)
+		{
+			if (a.IsIdle)
+				return false;
+
+			var activity = a.CurrentActivity;
+			if (activity.GetType() == typeof(Resupply))
+				return true;
+
+			var next = activity.NextActivity;
+			if (next == null)
+				return false;
+
+			if (next.GetType() == typeof(Resupply))
+				return true;
+
+			return false;
+		}
+
+		protected static bool FullAmmo(IEnumerable<AmmoPool> ammoPools)
+		{
+			foreach (var ap in ammoPools)
+				if (!ap.HasFullAmmo)
+					return false;
+
+			return true;
+		}
+
+		protected static bool HasAmmo(IEnumerable<AmmoPool> ammoPools)
+		{
+			foreach (var ap in ammoPools)
+				if (!ap.HasAmmo)
+					return false;
+
+			return true;
+		}
+
+		protected static bool ReloadsAutomatically(IEnumerable<AmmoPool> ammoPools, Rearmable rearmable)
+		{
+			if (rearmable == null)
+				return true;
+
+			foreach (var ap in ammoPools)
+				if (!rearmable.Info.AmmoPools.Contains(ap.Info.Name))
+					return false;
+
+			return true;
+		}
+
+		// Retreat units from combat, or for supply only in idle
+		protected void Retreat(Squad squad, bool flee, bool rearm, bool repair)
+		{
+			var loc = new CPos(0, 0, 0);
+
+			// HACK: "alreadyRepair" is to solve repairpad performance
+			// if repairpad logic is better we will only need
+			// this function for all flee states.
+			var alreadyRepair = false;
+
+			if (flee)
+				loc = RandomBuildingLocation(squad);
+
+			foreach (var a in squad.Units)
+			{
+				if (IsRearming(a))
+					continue;
+
+				var orderQueued = false;
+
+				// Try rearm units.
+				if (rearm)
+				{
+					var ammoPools = a.TraitsImplementing<AmmoPool>().ToArray();
+					if (!ReloadsAutomatically(ammoPools, a.TraitOrDefault<Rearmable>()) && !FullAmmo(ammoPools))
+					{
+						squad.Bot.QueueOrder(new Order("ReturnToBase", a, orderQueued));
+						orderQueued = true;
+					}
+				}
+
+				// Try repair units.
+				if (repair && !alreadyRepair)
+				{
+					Actor repairBuilding = null;
+					var orderId = "Repair";
+					var health = a.TraitOrDefault<IHealth>();
+
+					if (health != null && health.DamageState > DamageState.Undamaged)
+					{
+						var repairable = a.TraitOrDefault<Repairable>();
+						if (repairable != null)
+							repairBuilding = repairable.FindRepairBuilding(a);
+						else
+						{
+							var repairableNear = a.TraitOrDefault<RepairableNear>();
+							if (repairableNear != null)
+							{
+								orderId = "RepairNear";
+								repairBuilding = repairableNear.FindRepairBuilding(a);
+							}
+						}
+
+						if (repairBuilding != null)
+						{
+							squad.Bot.QueueOrder(new Order(orderId, a, Target.FromActor(repairBuilding), orderQueued));
+							orderQueued = true;
+							alreadyRepair = true;
+						}
+					}
+				}
+
+				// If there is no order in queue and units should flee, try flee.
+				if (flee && !orderQueued)
+					squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), false));
+			}
 		}
 	}
 }


### PR DESCRIPTION
~~**Warning, please choose which PR to merge, this PR or [that PR in mod SDK](https://github.com/ABrandau/Shattered-Paradise-SDK/pull/39)**~~

~~**Merging this PR may lead to engine upgrade more difficult, and make engine maintenance harder when you both upgrade the engine and fix related files . But it is simpler in code compared to the the other PR above.**~~

- AI will ignore invisible enemy when attacking, which will improve NOD players and mine layer game experience. (merged by upstream)  

- AI units will receive repair order when retreat. 

- AI will turn on/off buildings depending on power (if you apply this you need to add the trait in AI.yaml) . AI will not only wait for another powerplant, they will cut off power and make production back to normal!

- AI Ground state:
1. AttackMove State: it is optimized and take new method on pathfinding and regrouping, which fix bug that in some SP/TS/RA2/RV map, AI ground force will stuck and take a lot of resource on pathfinding and lag the game while cannot make any progress.
Especially this map. The nightmare map for AI to go through, and it was the final map among test maps for me to test AttackMove State fixes at that time.
<img width="400" alt="capture" src="https://user-images.githubusercontent.com/13763394/89297718-e85bf300-d696-11ea-97f8-7f9a0593b1cc.PNG">

2. Attack State: When there is target which is more close to team leader, entire team will switch target to prevent ambush. When there is no visible target in range, Attack State will switch back to AttackMove State.

- AI Air State:
1. Apply target choosing randomized (by @darkademic) 
2. AI aircrafts will scan threat around team leader and try retreat when get ambushed. 

- AI Protection State:
Give some of Air State logic for air units in protection team. 

**Note: if Mustapha is going to update SP engine to newest bleed, then the `IsEnemyUnit` will be changed to `IsPreferredEnemyUnit` in many squad states.**